### PR TITLE
explicitly state the format of the template

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ source "http://rubygems.org"
 group :development do
   gem 'rake', '>= 0'
   gem "shoulda", ">= 0"
-  gem "bundler", "~> 1.0.0"
+  gem "bundler", "~> 1.0"
   gem "jeweler", "~> 1.6.0"
   gem "rcov", ">= 0"
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,6 @@
 en:
   errship:
+    standard: 'An unknown error has occurred, or you have reached this page by mistake.'
     '404':
       title: 'This page does not exist.'
       description: 'It could have moved, or someone (maybe you!) mistyped the URL.'

--- a/lib/errship.rb
+++ b/lib/errship.rb
@@ -23,21 +23,27 @@ module Errship
 
     def render_error(exception, errship_scope = false)
       airbrake_class.send(:notify, exception) if airbrake_class
-      render :template => '/errship/standard', :locals => {
-        :status_code => 500, :errship_scope => errship_scope }, :status => (Errship.status_code_success ? 200 : 500)
+      render :template => '/errship/standard.html.erb',
+             :layout   => 'application',
+             :locals   => { :status_code => 500, :errship_scope => errship_scope },
+             :status   => (Errship.status_code_success ? 200 : 500)
     end
 
     def render_404_error(exception = nil, errship_scope = false)
-      render :template => '/errship/standard', :locals => {
-        :status_code => 404, :errship_scope => errship_scope }, :status => (Errship.status_code_success ? 200 : 404)
+      render :template => '/errship/standard.html.erb',
+             :layout   => 'application',
+             :locals   => { :status_code => 404, :errship_scope => errship_scope },
+             :status   => (Errship.status_code_success ? 200 : 404)
     end
 
     # A blank page with just the layout and flash message, which can be redirected to when
     # all else fails.
     def errship_standard(errship_scope = false)
       flash[:error] ||= 'An unknown error has occurred, or you have reached this page by mistake.'
-      render :template => '/errship/standard', :locals => {
-        :status_code => 500, :errship_scope => errship_scope }
+      render :template => '/errship/standard.html.erb',
+             :layout   => 'application',
+             :locals   => { :status_code => 500, :errship_scope => errship_scope },
+             :status   => (Errship.status_code_success ? 200 : 500)
     end
 
     # Set the error flash and attempt to redirect back. If RedirectBackError is raised,

--- a/lib/errship.rb
+++ b/lib/errship.rb
@@ -39,7 +39,7 @@ module Errship
     # A blank page with just the layout and flash message, which can be redirected to when
     # all else fails.
     def errship_standard(errship_scope = false)
-      flash[:error] ||= 'An unknown error has occurred, or you have reached this page by mistake.'
+      flash[:error] ||= I18n.t('errship.standard')
       render :template => '/errship/standard.html.erb',
              :layout   => 'application',
              :locals   => { :status_code => 500, :errship_scope => errship_scope },


### PR DESCRIPTION
Hi,
this pull request includes one important fix and two minor ones:
1. State the format explicitly when rendering the error-partial. The reason is that I was getting errors when a route with a format was accessed, such as "http://www.domain.tld/stylesheets/base.css". Rails was complaining that there was no view with an css extension it could render.
2. I relaxed the bundler requirement as I'm using bundler 1.1.rc
3. I took the hardcoded string for the errship_standard and make it i18n.
